### PR TITLE
fix: creator indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blockbuster"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anchor-lang",
  "async-trait",

--- a/blockbuster/Cargo.toml
+++ b/blockbuster/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blockbuster"
 description = "Metaplex canonical program parsers, for indexing, analytics etc...."
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/blockbuster"
 license = "AGPL-3.0"


### PR DESCRIPTION
## Overview
- The data and creator has changes after a creator is verified or unverified. We need to feed the right data to the indexer via blockbuster for us to index the changes correctly.

## Testing
- Locally with regular mints + this verifyCreator txn: "3x9ciwFMjtNcjp5es8icppiaAW7SR4y4uKUsoKfQ3oRLLodQnTyVn8NcbdKAHjYJTve1wzRjAXiUQYbGV5NXmSjf" 
